### PR TITLE
feat: 🎸 node 编译插件支持配置自动包裹上 express 参数 wrapExpress

### DIFF
--- a/packages/cloudbase-node-builder/asset/__launcher.js
+++ b/packages/cloudbase-node-builder/asset/__launcher.js
@@ -1,6 +1,11 @@
 module.exports.main = async (event, context) => {
   context.callbackWaitsForEmptyEventLoop = false;
-  const entry = require('.//*entryPath*/');
+  const entry = (() => {
+    let result = require('.//*entryPath*/');
+    //#wrapExpress const app = require('express')();
+    //#wrapExpress result = app.use(result);
+    return result;
+  })();
   const serverless = require('serverless-http');
   let app = entry;
 

--- a/packages/cloudbase-node-builder/src/index.ts
+++ b/packages/cloudbase-node-builder/src/index.ts
@@ -14,6 +14,7 @@ interface NodeBuilderBuildOptions {
    */
   path: string;
   name: string;
+  wrapExpress?: boolean;
 }
 
 interface NodeBuilderOptions {
@@ -38,7 +39,11 @@ export class NodeBuilder extends Builder {
   async build(entry: string, options?: NodeBuilderBuildOptions) {
     const { distDir, projectDir, distDirName } = this;
     const entryFile = path.resolve(projectDir, entry);
-    const functionName = options?.name || "nodeapp";
+    // const functionName = options?.name || "nodeapp";
+    const {
+      name: functionName = 'nodeapp',
+      wrapExpress = false,
+    } = options || {};
     const appDir = path.join(distDir, functionName);
 
     const packageJson = await this.generatePackageJson(functionName, entryFile);
@@ -54,6 +59,7 @@ export class NodeBuilder extends Builder {
     await fse.writeFile(
       path.resolve(appDir, "./tcbindex.js"),
       __launcher.replace("/*entryPath*/", entryRelativePath)
+        .replace(/\/\/#wrapExpress\s/g, wrapExpress ? '' : '// ')
     );
 
     await fse.copy(path.resolve(projectDir), path.join(appDir));

--- a/packages/cloudbase-node-builder/src/index.ts
+++ b/packages/cloudbase-node-builder/src/index.ts
@@ -39,7 +39,6 @@ export class NodeBuilder extends Builder {
   async build(entry: string, options?: NodeBuilderBuildOptions) {
     const { distDir, projectDir, distDirName } = this;
     const entryFile = path.resolve(projectDir, entry);
-    // const functionName = options?.name || "nodeapp";
     const {
       name: functionName = 'nodeapp',
       wrapExpress = false,

--- a/packages/framework-plugin-node/README.md
+++ b/packages/framework-plugin-node/README.md
@@ -184,6 +184,40 @@ exports.tcbGetApp = async () => {
 }
 ```
 
+### `wrapExpress`
+选填，当 `platform` 选择 `function` 时，可以支持自动为函数包上一层 express
+
+例如
+
+```json
+{
+  "envId": "fx",
+  "framework": {
+    "plugins": {
+      "server": {
+        "use": "@cloudbase/framework-plugin-node",
+        "inputs": {
+          "entry": "./api/index.js",
+          "path": "/api",
+          "name": "github-stats-api",
+          "wrapExpress": true
+        }
+      },
+      "pin": {
+        "use": "@cloudbase/framework-plugin-node",
+        "inputs": {
+          "entry": "./api/pin.js",
+          "path": "/api/pin",
+          "name": "github-stats-pin",
+          "wrapExpress": true
+        }
+      }
+    }
+  }
+}
+```
+
+
 具体配置信息请参考 [@cloudbase/framework-plugin-function](https://github.com/TencentCloudBase/cloudbase-framework/blob/master/packages/framework-plugin-function/README.md#functions) 配置
 
 ## 更多插件

--- a/packages/framework-plugin-node/src/index.ts
+++ b/packages/framework-plugin-node/src/index.ts
@@ -25,6 +25,7 @@ class NodePlugin extends Plugin {
       name: "node",
       projectPath: ".",
       platform: "function",
+      wrapExpress: false,
     };
 
     this.resolvedInputs = resolveInputs(this.inputs, DEFAULT_INPUTS);

--- a/packages/framework-plugin-node/src/node-function-impl.ts
+++ b/packages/framework-plugin-node/src/node-function-impl.ts
@@ -62,6 +62,7 @@ class NodeFunctionPlugin extends Plugin {
     this.buildOutput = await this.nodeBuilder.build(this.resolvedInputs.entry, {
       path: this.resolvedInputs.path,
       name: this.resolvedInputs.name,
+      wrapExpress: this.resolvedInputs.wrapExpress,
     });
 
     const srcFunction = this.buildOutput.functions[0];

--- a/packages/framework-plugin-node/src/types.ts
+++ b/packages/framework-plugin-node/src/types.ts
@@ -11,4 +11,5 @@ export interface INodePluginInputs {
   functionOptions?: any;
   installDeps: boolean;
   buildCommand?: string;
+  wrapExpress?: boolean;
 }


### PR DESCRIPTION
Node 插件支持 Vercel 风格的api 文件
支持将纯的 hanlder 函数包装成 Node 应用并部署

Vercel 风格 API 文件格式
```
module.exports = async (req, res) => {

};
```

@binggg
